### PR TITLE
Correct mistyped variable name - Longitude Shortcode

### DIFF
--- a/wpengine-geoip.php
+++ b/wpengine-geoip.php
@@ -281,7 +281,7 @@ class GeoIp {
 		if( isset( $this->geos[ 'longitude' ] ) ) {
 			return $this->longitude();
 		}
-		return '[' . self::SHORTCODE_longitude . ']';
+		return '[' . self::SHORTCODE_LONGITUDE . ']';
 	}
 
 	/**


### PR DESCRIPTION
`SHORTCODE_longitude` should be all uppercase.