### PR TITLE
Fix dismissable notice & readme

### DIFF
--- a/inc/country-list.php
+++ b/inc/country-list.php
@@ -1,256 +1,992 @@
 <?php
 /**
- * Generates an array of country codes and their respective continents
+ * Provides the master list of country info for the country-continent match-up
  *
+ * @package wpengine-geoip
  */
 
+/**
+ * Returns an array of country codes and their respective continents
+ */
 function geoip_country_list() {
 
 	$countries = array(
-		"AF" => array("country" => "Afghanistan", "continent" => "AS"),
-		"AX" => array("country" => "Åland Islands", "continent" => "EU"),
-		"AL" => array("country" => "Albania", "continent" => "EU"),
-		"DZ" => array("country" => "Algeria", "continent" => "AF"),
-		"AS" => array("country" => "American Samoa", "continent" => "OC"),
-		"AD" => array("country" => "Andorra", "continent" => "EU"),
-		"AO" => array("country" => "Angola", "continent" => "AF"),
-		"AI" => array("country" => "Anguilla", "continent" => "NA"),
-		"AQ" => array("country" => "AN", "continent" => "AN"),
-		"AG" => array("country" => "Antigua and Barbuda", "continent" => "NA"),
-		"AR" => array("country" => "Argentina", "continent" => "SA"),
-		"AM" => array("country" => "Armenia", "continent" => "AS"),
-		"AW" => array("country" => "Aruba", "continent" => "NA"),
-		"AU" => array("country" => "Australia", "continent" => "OC"),
-		"AT" => array("country" => "Austria", "continent" => "EU"),
-		"AZ" => array("country" => "Azerbaijan", "continent" => "AS"),
-		"BS" => array("country" => "Bahamas", "continent" => "NA"),
-		"BH" => array("country" => "Bahrain", "continent" => "AS"),
-		"BD" => array("country" => "Bangladesh", "continent" => "AS"),
-		"BB" => array("country" => "Barbados", "continent" => "NA"),
-		"BY" => array("country" => "Belarus", "continent" => "EU"),
-		"BE" => array("country" => "Belgium", "continent" => "EU"),
-		"BZ" => array("country" => "Belize", "continent" => "NA"),
-		"BJ" => array("country" => "Benin", "continent" => "AF"),
-		"BM" => array("country" => "Bermuda", "continent" => "NA"),
-		"BT" => array("country" => "Bhutan", "continent" => "AS"),
-		"BO" => array("country" => "Bolivia", "continent" => "SA"),
-		"BA" => array("country" => "Bosnia and Herzegovina", "continent" => "EU"),
-		"BW" => array("country" => "Botswana", "continent" => "AF"),
-		"BV" => array("country" => "Bouvet Island", "continent" => "AN"),
-		"BR" => array("country" => "Brazil", "continent" => "SA"),
-		"IO" => array("country" => "British Indian Ocean Territory", "continent" => "AS"),
-		"BN" => array("country" => "Brunei Darussalam", "continent" => "AS"),
-		"BG" => array("country" => "Bulgaria", "continent" => "EU"),
-		"BF" => array("country" => "Burkina Faso", "continent" => "AF"),
-		"BI" => array("country" => "Burundi", "continent" => "AF"),
-		"KH" => array("country" => "Cambodia", "continent" => "AS"),
-		"CM" => array("country" => "Cameroon", "continent" => "AF"),
-		"CA" => array("country" => "Canada", "continent" => "NA"),
-		"CV" => array("country" => "Cape Verde", "continent" => "AF"),
-		"KY" => array("country" => "Cayman Islands", "continent" => "NA"),
-		"CF" => array("country" => "Central African Republic", "continent" => "AF"),
-		"TD" => array("country" => "Chad", "continent" => "AF"),
-		"CL" => array("country" => "Chile", "continent" => "SA"),
-		"CN" => array("country" => "China", "continent" => "AS"),
-		"CX" => array("country" => "Christmas Island", "continent" => "AS"),
-		"CC" => array("country" => "Cocos (Keeling) Islands", "continent" => "AS"),
-		"CO" => array("country" => "Colombia", "continent" => "SA"),
-		"KM" => array("country" => "Comoros", "continent" => "AF"),
-		"CG" => array("country" => "Congo", "continent" => "AF"),
-		"CD" => array("country" => "The Democratic Republic of The Congo", "continent" => "AF"),
-		"CK" => array("country" => "Cook Islands", "continent" => "OC"),
-		"CR" => array("country" => "Costa Rica", "continent" => "NA"),
-		"CI" => array("country" => "Cote D'ivoire", "continent" => "AF"),
-		"HR" => array("country" => "Croatia", "continent" => "EU"),
-		"CU" => array("country" => "Cuba", "continent" => "NA"),
-		"CY" => array("country" => "Cyprus", "continent" => "AS"),
-		"CZ" => array("country" => "Czech Republic", "continent" => "EU"),
-		"DK" => array("country" => "Denmark", "continent" => "EU"),
-		"DJ" => array("country" => "Djibouti", "continent" => "AF"),
-		"DM" => array("country" => "Dominica", "continent" => "NA"),
-		"DO" => array("country" => "Dominican Republic", "continent" => "NA"),
-		"EC" => array("country" => "Ecuador", "continent" => "SA"),
-		"EG" => array("country" => "Egypt", "continent" => "AF"),
-		"SV" => array("country" => "El Salvador", "continent" => "NA"),
-		"GQ" => array("country" => "Equatorial Guinea", "continent" => "AF"),
-		"ER" => array("country" => "Eritrea", "continent" => "AF"),
-		"EE" => array("country" => "Estonia", "continent" => "EU"),
-		"ET" => array("country" => "Ethiopia", "continent" => "AF"),
-		"FK" => array("country" => "Falkland Islands (Malvinas)", "continent" => "SA"),
-		"FO" => array("country" => "Faroe Islands", "continent" => "EU"),
-		"FJ" => array("country" => "Fiji", "continent" => "OC"),
-		"FI" => array("country" => "Finland", "continent" => "EU"),
-		"FR" => array("country" => "France", "continent" => "EU"),
-		"GF" => array("country" => "French Guiana", "continent" => "SA"),
-		"PF" => array("country" => "French Polynesia", "continent" => "OC"),
-		"TF" => array("country" => "French Southern Territories", "continent" => "AN"),
-		"GA" => array("country" => "Gabon", "continent" => "AF"),
-		"GM" => array("country" => "Gambia", "continent" => "AF"),
-		"GE" => array("country" => "Georgia", "continent" => "AS"),
-		"DE" => array("country" => "Germany", "continent" => "EU"),
-		"GH" => array("country" => "Ghana", "continent" => "AF"),
-		"GI" => array("country" => "Gibraltar", "continent" => "EU"),
-		"GR" => array("country" => "Greece", "continent" => "EU"),
-		"GL" => array("country" => "Greenland", "continent" => "NA"),
-		"GD" => array("country" => "Grenada", "continent" => "NA"),
-		"GP" => array("country" => "Guadeloupe", "continent" => "NA"),
-		"GU" => array("country" => "Guam", "continent" => "OC"),
-		"GT" => array("country" => "Guatemala", "continent" => "NA"),
-		"GG" => array("country" => "Guernsey", "continent" => "EU"),
-		"GN" => array("country" => "Guinea", "continent" => "AF"),
-		"GW" => array("country" => "Guinea-bissau", "continent" => "AF"),
-		"GY" => array("country" => "Guyana", "continent" => "SA"),
-		"HT" => array("country" => "Haiti", "continent" => "NA"),
-		"HM" => array("country" => "Heard Island and Mcdonald Islands", "continent" => "AN"),
-		"VA" => array("country" => "Holy See (Vatican City State)", "continent" => "EU"),
-		"HN" => array("country" => "Honduras", "continent" => "NA"),
-		"HK" => array("country" => "Hong Kong", "continent" => "AS"),
-		"HU" => array("country" => "Hungary", "continent" => "EU"),
-		"IS" => array("country" => "Iceland", "continent" => "EU"),
-		"IN" => array("country" => "India", "continent" => "AS"),
-		"ID" => array("country" => "Indonesia", "continent" => "AS"),
-		"IR" => array("country" => "Iran", "continent" => "AS"),
-		"IQ" => array("country" => "Iraq", "continent" => "AS"),
-		"IE" => array("country" => "Ireland", "continent" => "EU"),
-		"IM" => array("country" => "Isle of Man", "continent" => "EU"),
-		"IL" => array("country" => "Israel", "continent" => "AS"),
-		"IT" => array("country" => "Italy", "continent" => "EU"),
-		"JM" => array("country" => "Jamaica", "continent" => "NA"),
-		"JP" => array("country" => "Japan", "continent" => "AS"),
-		"JE" => array("country" => "Jersey", "continent" => "EU"),
-		"JO" => array("country" => "Jordan", "continent" => "AS"),
-		"KZ" => array("country" => "Kazakhstan", "continent" => "AS"),
-		"KE" => array("country" => "Kenya", "continent" => "AF"),
-		"KI" => array("country" => "Kiribati", "continent" => "OC"),
-		"KP" => array("country" => "Democratic People's Republic of Korea", "continent" => "AS"),
-		"KR" => array("country" => "Republic of Korea", "continent" => "AS"),
-		"KW" => array("country" => "Kuwait", "continent" => "AS"),
-		"KG" => array("country" => "Kyrgyzstan", "continent" => "AS"),
-		"LA" => array("country" => "Lao People's Democratic Republic", "continent" => "AS"),
-		"LV" => array("country" => "Latvia", "continent" => "EU"),
-		"LB" => array("country" => "Lebanon", "continent" => "AS"),
-		"LS" => array("country" => "Lesotho", "continent" => "AF"),
-		"LR" => array("country" => "Liberia", "continent" => "AF"),
-		"LY" => array("country" => "Libya", "continent" => "AF"),
-		"LI" => array("country" => "Liechtenstein", "continent" => "EU"),
-		"LT" => array("country" => "Lithuania", "continent" => "EU"),
-		"LU" => array("country" => "Luxembourg", "continent" => "EU"),
-		"MO" => array("country" => "Macao", "continent" => "AS"),
-		"MK" => array("country" => "Macedonia", "continent" => "EU"),
-		"MG" => array("country" => "Madagascar", "continent" => "AF"),
-		"MW" => array("country" => "Malawi", "continent" => "AF"),
-		"MY" => array("country" => "Malaysia", "continent" => "AS"),
-		"MV" => array("country" => "Maldives", "continent" => "AS"),
-		"ML" => array("country" => "Mali", "continent" => "AF"),
-		"MT" => array("country" => "Malta", "continent" => "EU"),
-		"MH" => array("country" => "Marshall Islands", "continent" => "OC"),
-		"MQ" => array("country" => "Martinique", "continent" => "NA"),
-		"MR" => array("country" => "Mauritania", "continent" => "AF"),
-		"MU" => array("country" => "Mauritius", "continent" => "AF"),
-		"YT" => array("country" => "Mayotte", "continent" => "AF"),
-		"MX" => array("country" => "Mexico", "continent" => "NA"),
-		"FM" => array("country" => "Micronesia", "continent" => "OC"),
-		"MD" => array("country" => "Moldova", "continent" => "EU"),
-		"MC" => array("country" => "Monaco", "continent" => "EU"),
-		"MN" => array("country" => "Mongolia", "continent" => "AS"),
-		"ME" => array("country" => "Montenegro", "continent" => "EU"),
-		"MS" => array("country" => "Montserrat", "continent" => "NA"),
-		"MA" => array("country" => "Morocco", "continent" => "AF"),
-		"MZ" => array("country" => "Mozambique", "continent" => "AF"),
-		"MM" => array("country" => "Myanmar", "continent" => "AS"),
-		"NA" => array("country" => "Namibia", "continent" => "AF"),
-		"NR" => array("country" => "Nauru", "continent" => "OC"),
-		"NP" => array("country" => "Nepal", "continent" => "AS"),
-		"NL" => array("country" => "Netherlands", "continent" => "EU"),
-		"AN" => array("country" => "Netherlands Antilles", "continent" => "NA"),
-		"NC" => array("country" => "New Caledonia", "continent" => "OC"),
-		"NZ" => array("country" => "New Zealand", "continent" => "OC"),
-		"NI" => array("country" => "Nicaragua", "continent" => "NA"),
-		"NE" => array("country" => "Niger", "continent" => "AF"),
-		"NG" => array("country" => "Nigeria", "continent" => "AF"),
-		"NU" => array("country" => "Niue", "continent" => "OC"),
-		"NF" => array("country" => "Norfolk Island", "continent" => "OC"),
-		"MP" => array("country" => "Northern Mariana Islands", "continent" => "OC"),
-		"NO" => array("country" => "Norway", "continent" => "EU"),
-		"OM" => array("country" => "Oman", "continent" => "AS"),
-		"PK" => array("country" => "Pakistan", "continent" => "AS"),
-		"PW" => array("country" => "Palau", "continent" => "OC"),
-		"PS" => array("country" => "Palestinia", "continent" => "AS"),
-		"PA" => array("country" => "Panama", "continent" => "NA"),
-		"PG" => array("country" => "Papua New Guinea", "continent" => "OC"),
-		"PY" => array("country" => "Paraguay", "continent" => "SA"),
-		"PE" => array("country" => "Peru", "continent" => "SA"),
-		"PH" => array("country" => "Philippines", "continent" => "AS"),
-		"PN" => array("country" => "Pitcairn", "continent" => "OC"),
-		"PL" => array("country" => "Poland", "continent" => "EU"),
-		"PT" => array("country" => "Portugal", "continent" => "EU"),
-		"PR" => array("country" => "Puerto Rico", "continent" => "NA"),
-		"QA" => array("country" => "Qatar", "continent" => "AS"),
-		"RE" => array("country" => "Reunion", "continent" => "AF"),
-		"RO" => array("country" => "Romania", "continent" => "EU"),
-		"RU" => array("country" => "Russian Federation", "continent" => "EU"),
-		"RW" => array("country" => "Rwanda", "continent" => "AF"),
-		"SH" => array("country" => "Saint Helena", "continent" => "AF"),
-		"KN" => array("country" => "Saint Kitts and Nevis", "continent" => "NA"),
-		"LC" => array("country" => "Saint Lucia", "continent" => "NA"),
-		"PM" => array("country" => "Saint Pierre and Miquelon", "continent" => "NA"),
-		"VC" => array("country" => "Saint Vincent and The Grenadines", "continent" => "NA"),
-		"WS" => array("country" => "Samoa", "continent" => "OC"),
-		"SM" => array("country" => "San Marino", "continent" => "EU"),
-		"ST" => array("country" => "Sao Tome and Principe", "continent" => "AF"),
-		"SA" => array("country" => "Saudi Arabia", "continent" => "AS"),
-		"SN" => array("country" => "Senegal", "continent" => "AF"),
-		"RS" => array("country" => "Serbia", "continent" => "EU"),
-		"SC" => array("country" => "Seychelles", "continent" => "AF"),
-		"SL" => array("country" => "Sierra Leone", "continent" => "AF"),
-		"SG" => array("country" => "Singapore", "continent" => "AS"),
-		"SK" => array("country" => "Slovakia", "continent" => "EU"),
-		"SI" => array("country" => "Slovenia", "continent" => "EU"),
-		"SB" => array("country" => "Solomon Islands", "continent" => "OC"),
-		"SO" => array("country" => "Somalia", "continent" => "AF"),
-		"ZA" => array("country" => "South Africa", "continent" => "AF"),
-		"GS" => array("country" => "South Georgia and The South Sandwich Islands", "continent" => "AN"),
-		"ES" => array("country" => "Spain", "continent" => "EU"),
-		"LK" => array("country" => "Sri Lanka", "continent" => "AS"),
-		"SD" => array("country" => "Sudan", "continent" => "AF"),
-		"SR" => array("country" => "Suriname", "continent" => "SA"),
-		"SJ" => array("country" => "Svalbard and Jan Mayen", "continent" => "EU"),
-		"SZ" => array("country" => "Swaziland", "continent" => "AF"),
-		"SE" => array("country" => "Sweden", "continent" => "EU"),
-		"CH" => array("country" => "Switzerland", "continent" => "EU"),
-		"SY" => array("country" => "Syrian Arab Republic", "continent" => "AS"),
-		"TW" => array("country" => "Taiwan, Province of China", "continent" => "AS"),
-		"TJ" => array("country" => "Tajikistan", "continent" => "AS"),
-		"TZ" => array("country" => "Tanzania, United Republic of", "continent" => "AF"),
-		"TH" => array("country" => "Thailand", "continent" => "AS"),
-		"TL" => array("country" => "Timor-leste", "continent" => "AS"),
-		"TG" => array("country" => "Togo", "continent" => "AF"),
-		"TK" => array("country" => "Tokelau", "continent" => "OC"),
-		"TO" => array("country" => "Tonga", "continent" => "OC"),
-		"TT" => array("country" => "Trinidad and Tobago", "continent" => "NA"),
-		"TN" => array("country" => "Tunisia", "continent" => "AF"),
-		"TR" => array("country" => "Turkey", "continent" => "AS"),
-		"TM" => array("country" => "Turkmenistan", "continent" => "AS"),
-		"TC" => array("country" => "Turks and Caicos Islands", "continent" => "NA"),
-		"TV" => array("country" => "Tuvalu", "continent" => "OC"),
-		"UG" => array("country" => "Uganda", "continent" => "AF"),
-		"UA" => array("country" => "Ukraine", "continent" => "EU"),
-		"AE" => array("country" => "United Arab Emirates", "continent" => "AS"),
-		"GB" => array("country" => "United Kingdom", "continent" => "EU"),
-		"US" => array("country" => "United States", "continent" => "NA"),
-		"UM" => array("country" => "United States Minor Outlying Islands", "continent" => "OC"),
-		"UY" => array("country" => "Uruguay", "continent" => "SA"),
-		"UZ" => array("country" => "Uzbekistan", "continent" => "AS"),
-		"VU" => array("country" => "Vanuatu", "continent" => "OC"),
-		"VE" => array("country" => "Venezuela", "continent" => "SA"),
-		"VN" => array("country" => "Viet Nam", "continent" => "AS"),
-		"VG" => array("country" => "Virgin Islands, British", "continent" => "NA"),
-		"VI" => array("country" => "Virgin Islands, U.S.", "continent" => "NA"),
-		"WF" => array("country" => "Wallis and Futuna", "continent" => "OC"),
-		"EH" => array("country" => "Western Sahara", "continent" => "AF"),
-		"YE" => array("country" => "Yemen", "continent" => "AS"),
-		"ZM" => array("country" => "Zambia", "continent" => "AF"),
-		"ZW" => array("country" => "Zimbabwe", "continent" => "AF")
+		'AF' => array(
+			'country' => 'Afghanistan',
+			'continent' => 'AS',
+		),
+		'AX' => array(
+			'country' => 'Åland Islands',
+			'continent' => 'EU',
+		),
+		'AL' => array(
+			'country' => 'Albania',
+			'continent' => 'EU',
+		),
+		'DZ' => array(
+			'country' => 'Algeria',
+			'continent' => 'AF',
+		),
+		'AS' => array(
+			'country' => 'American Samoa',
+			'continent' => 'OC',
+		),
+		'AD' => array(
+			'country' => 'Andorra',
+			'continent' => 'EU',
+		),
+		'AO' => array(
+			'country' => 'Angola',
+			'continent' => 'AF',
+		),
+		'AI' => array(
+			'country' => 'Anguilla',
+			'continent' => 'NA',
+		),
+		'AQ' => array(
+			'country' => 'AN',
+			'continent' => 'AN',
+		),
+		'AG' => array(
+			'country' => 'Antigua and Barbuda',
+			'continent' => 'NA',
+		),
+		'AR' => array(
+			'country' => 'Argentina',
+			'continent' => 'SA',
+		),
+		'AM' => array(
+			'country' => 'Armenia',
+			'continent' => 'AS',
+		),
+		'AW' => array(
+			'country' => 'Aruba',
+			'continent' => 'NA',
+		),
+		'AU' => array(
+			'country' => 'Australia',
+			'continent' => 'OC',
+		),
+		'AT' => array(
+			'country' => 'Austria',
+			'continent' => 'EU',
+		),
+		'AZ' => array(
+			'country' => 'Azerbaijan',
+			'continent' => 'AS',
+		),
+		'BS' => array(
+			'country' => 'Bahamas',
+			'continent' => 'NA',
+		),
+		'BH' => array(
+			'country' => 'Bahrain',
+			'continent' => 'AS',
+		),
+		'BD' => array(
+			'country' => 'Bangladesh',
+			'continent' => 'AS',
+		),
+		'BB' => array(
+			'country' => 'Barbados',
+			'continent' => 'NA',
+		),
+		'BY' => array(
+			'country' => 'Belarus',
+			'continent' => 'EU',
+		),
+		'BE' => array(
+			'country' => 'Belgium',
+			'continent' => 'EU',
+		),
+		'BZ' => array(
+			'country' => 'Belize',
+			'continent' => 'NA',
+		),
+		'BJ' => array(
+			'country' => 'Benin',
+			'continent' => 'AF',
+		),
+		'BM' => array(
+			'country' => 'Bermuda',
+			'continent' => 'NA',
+		),
+		'BT' => array(
+			'country' => 'Bhutan',
+			'continent' => 'AS',
+		),
+		'BO' => array(
+			'country' => 'Bolivia',
+			'continent' => 'SA',
+		),
+		'BA' => array(
+			'country' => 'Bosnia and Herzegovina',
+			'continent' => 'EU',
+		),
+		'BW' => array(
+			'country' => 'Botswana',
+			'continent' => 'AF',
+		),
+		'BV' => array(
+			'country' => 'Bouvet Island',
+			'continent' => 'AN',
+		),
+		'BR' => array(
+			'country' => 'Brazil',
+			'continent' => 'SA',
+		),
+		'IO' => array(
+			'country' => 'British Indian Ocean Territory',
+			'continent' => 'AS',
+		),
+		'BN' => array(
+			'country' => 'Brunei Darussalam',
+			'continent' => 'AS',
+		),
+		'BG' => array(
+			'country' => 'Bulgaria',
+			'continent' => 'EU',
+		),
+		'BF' => array(
+			'country' => 'Burkina Faso',
+			'continent' => 'AF',
+		),
+		'BI' => array(
+			'country' => 'Burundi',
+			'continent' => 'AF',
+		),
+		'KH' => array(
+			'country' => 'Cambodia',
+			'continent' => 'AS',
+		),
+		'CM' => array(
+			'country' => 'Cameroon',
+			'continent' => 'AF',
+		),
+		'CA' => array(
+			'country' => 'Canada',
+			'continent' => 'NA',
+		),
+		'CV' => array(
+			'country' => 'Cape Verde',
+			'continent' => 'AF',
+		),
+		'KY' => array(
+			'country' => 'Cayman Islands',
+			'continent' => 'NA',
+		),
+		'CF' => array(
+			'country' => 'Central African Republic',
+			'continent' => 'AF',
+		),
+		'TD' => array(
+			'country' => 'Chad',
+			'continent' => 'AF',
+		),
+		'CL' => array(
+			'country' => 'Chile',
+			'continent' => 'SA',
+		),
+		'CN' => array(
+			'country' => 'China',
+			'continent' => 'AS',
+		),
+		'CX' => array(
+			'country' => 'Christmas Island',
+			'continent' => 'AS',
+		),
+		'CC' => array(
+			'country' => 'Cocos (Keeling) Islands',
+			'continent' => 'AS',
+		),
+		'CO' => array(
+			'country' => 'Colombia',
+			'continent' => 'SA',
+		),
+		'KM' => array(
+			'country' => 'Comoros',
+			'continent' => 'AF',
+		),
+		'CG' => array(
+			'country' => 'Congo',
+			'continent' => 'AF',
+		),
+		'CD' => array(
+			'country' => 'The Democratic Republic of The Congo',
+			'continent' => 'AF',
+		),
+		'CK' => array(
+			'country' => 'Cook Islands',
+			'continent' => 'OC',
+		),
+		'CR' => array(
+			'country' => 'Costa Rica',
+			'continent' => 'NA',
+		),
+		'CI' => array(
+			'country' => 'Cote D\'ivoire',
+			'continent' => 'AF',
+		),
+		'HR' => array(
+			'country' => 'Croatia',
+			'continent' => 'EU',
+		),
+		'CU' => array(
+			'country' => 'Cuba',
+			'continent' => 'NA',
+		),
+		'CY' => array(
+			'country' => 'Cyprus',
+			'continent' => 'AS',
+		),
+		'CZ' => array(
+			'country' => 'Czech Republic',
+			'continent' => 'EU',
+		),
+		'DK' => array(
+			'country' => 'Denmark',
+			'continent' => 'EU',
+		),
+		'DJ' => array(
+			'country' => 'Djibouti',
+			'continent' => 'AF',
+		),
+		'DM' => array(
+			'country' => 'Dominica',
+			'continent' => 'NA',
+		),
+		'DO' => array(
+			'country' => 'Dominican Republic',
+			'continent' => 'NA',
+		),
+		'EC' => array(
+			'country' => 'Ecuador',
+			'continent' => 'SA',
+		),
+		'EG' => array(
+			'country' => 'Egypt',
+			'continent' => 'AF',
+		),
+		'SV' => array(
+			'country' => 'El Salvador',
+			'continent' => 'NA',
+		),
+		'GQ' => array(
+			'country' => 'Equatorial Guinea',
+			'continent' => 'AF',
+		),
+		'ER' => array(
+			'country' => 'Eritrea',
+			'continent' => 'AF',
+		),
+		'EE' => array(
+			'country' => 'Estonia',
+			'continent' => 'EU',
+		),
+		'ET' => array(
+			'country' => 'Ethiopia',
+			'continent' => 'AF',
+		),
+		'FK' => array(
+			'country' => 'Falkland Islands (Malvinas)',
+			'continent' => 'SA',
+		),
+		'FO' => array(
+			'country' => 'Faroe Islands',
+			'continent' => 'EU',
+		),
+		'FJ' => array(
+			'country' => 'Fiji',
+			'continent' => 'OC',
+		),
+		'FI' => array(
+			'country' => 'Finland',
+			'continent' => 'EU',
+		),
+		'FR' => array(
+			'country' => 'France',
+			'continent' => 'EU',
+		),
+		'GF' => array(
+			'country' => 'French Guiana',
+			'continent' => 'SA',
+		),
+		'PF' => array(
+			'country' => 'French Polynesia',
+			'continent' => 'OC',
+		),
+		'TF' => array(
+			'country' => 'French Southern Territories',
+			'continent' => 'AN',
+		),
+		'GA' => array(
+			'country' => 'Gabon',
+			'continent' => 'AF',
+		),
+		'GM' => array(
+			'country' => 'Gambia',
+			'continent' => 'AF',
+		),
+		'GE' => array(
+			'country' => 'Georgia',
+			'continent' => 'AS',
+		),
+		'DE' => array(
+			'country' => 'Germany',
+			'continent' => 'EU',
+		),
+		'GH' => array(
+			'country' => 'Ghana',
+			'continent' => 'AF',
+		),
+		'GI' => array(
+			'country' => 'Gibraltar',
+			'continent' => 'EU',
+		),
+		'GR' => array(
+			'country' => 'Greece',
+			'continent' => 'EU',
+		),
+		'GL' => array(
+			'country' => 'Greenland',
+			'continent' => 'NA',
+		),
+		'GD' => array(
+			'country' => 'Grenada',
+			'continent' => 'NA',
+		),
+		'GP' => array(
+			'country' => 'Guadeloupe',
+			'continent' => 'NA',
+		),
+		'GU' => array(
+			'country' => 'Guam',
+			'continent' => 'OC',
+		),
+		'GT' => array(
+			'country' => 'Guatemala',
+			'continent' => 'NA',
+		),
+		'GG' => array(
+			'country' => 'Guernsey',
+			'continent' => 'EU',
+		),
+		'GN' => array(
+			'country' => 'Guinea',
+			'continent' => 'AF',
+		),
+		'GW' => array(
+			'country' => 'Guinea-bissau',
+			'continent' => 'AF',
+		),
+		'GY' => array(
+			'country' => 'Guyana',
+			'continent' => 'SA',
+		),
+		'HT' => array(
+			'country' => 'Haiti',
+			'continent' => 'NA',
+		),
+		'HM' => array(
+			'country' => 'Heard Island and Mcdonald Islands',
+			'continent' => 'AN',
+		),
+		'VA' => array(
+			'country' => 'Holy See (Vatican City State)',
+			'continent' => 'EU',
+		),
+		'HN' => array(
+			'country' => 'Honduras',
+			'continent' => 'NA',
+		),
+		'HK' => array(
+			'country' => 'Hong Kong',
+			'continent' => 'AS',
+		),
+		'HU' => array(
+			'country' => 'Hungary',
+			'continent' => 'EU',
+		),
+		'IS' => array(
+			'country' => 'Iceland',
+			'continent' => 'EU',
+		),
+		'IN' => array(
+			'country' => 'India',
+			'continent' => 'AS',
+		),
+		'ID' => array(
+			'country' => 'Indonesia',
+			'continent' => 'AS',
+		),
+		'IR' => array(
+			'country' => 'Iran',
+			'continent' => 'AS',
+		),
+		'IQ' => array(
+			'country' => 'Iraq',
+			'continent' => 'AS',
+		),
+		'IE' => array(
+			'country' => 'Ireland',
+			'continent' => 'EU',
+		),
+		'IM' => array(
+			'country' => 'Isle of Man',
+			'continent' => 'EU',
+		),
+		'IL' => array(
+			'country' => 'Israel',
+			'continent' => 'AS',
+		),
+		'IT' => array(
+			'country' => 'Italy',
+			'continent' => 'EU',
+		),
+		'JM' => array(
+			'country' => 'Jamaica',
+			'continent' => 'NA',
+		),
+		'JP' => array(
+			'country' => 'Japan',
+			'continent' => 'AS',
+		),
+		'JE' => array(
+			'country' => 'Jersey',
+			'continent' => 'EU',
+		),
+		'JO' => array(
+			'country' => 'Jordan',
+			'continent' => 'AS',
+		),
+		'KZ' => array(
+			'country' => 'Kazakhstan',
+			'continent' => 'AS',
+		),
+		'KE' => array(
+			'country' => 'Kenya',
+			'continent' => 'AF',
+		),
+		'KI' => array(
+			'country' => 'Kiribati',
+			'continent' => 'OC',
+		),
+		'KP' => array(
+			'country' => 'Democratic People\'s Republic of Korea',
+			'continent' => 'AS',
+		),
+		'KR' => array(
+			'country' => 'Republic of Korea',
+			'continent' => 'AS',
+		),
+		'KW' => array(
+			'country' => 'Kuwait',
+			'continent' => 'AS',
+		),
+		'KG' => array(
+			'country' => 'Kyrgyzstan',
+			'continent' => 'AS',
+		),
+		'LA' => array(
+			'country' => 'Lao People\'s Democratic Republic',
+			'continent' => 'AS',
+		),
+		'LV' => array(
+			'country' => 'Latvia',
+			'continent' => 'EU',
+		),
+		'LB' => array(
+			'country' => 'Lebanon',
+			'continent' => 'AS',
+		),
+		'LS' => array(
+			'country' => 'Lesotho',
+			'continent' => 'AF',
+		),
+		'LR' => array(
+			'country' => 'Liberia',
+			'continent' => 'AF',
+		),
+		'LY' => array(
+			'country' => 'Libya',
+			'continent' => 'AF',
+		),
+		'LI' => array(
+			'country' => 'Liechtenstein',
+			'continent' => 'EU',
+		),
+		'LT' => array(
+			'country' => 'Lithuania',
+			'continent' => 'EU',
+		),
+		'LU' => array(
+			'country' => 'Luxembourg',
+			'continent' => 'EU',
+		),
+		'MO' => array(
+			'country' => 'Macao',
+			'continent' => 'AS',
+		),
+		'MK' => array(
+			'country' => 'Macedonia',
+			'continent' => 'EU',
+		),
+		'MG' => array(
+			'country' => 'Madagascar',
+			'continent' => 'AF',
+		),
+		'MW' => array(
+			'country' => 'Malawi',
+			'continent' => 'AF',
+		),
+		'MY' => array(
+			'country' => 'Malaysia',
+			'continent' => 'AS',
+		),
+		'MV' => array(
+			'country' => 'Maldives',
+			'continent' => 'AS',
+		),
+		'ML' => array(
+			'country' => 'Mali',
+			'continent' => 'AF',
+		),
+		'MT' => array(
+			'country' => 'Malta',
+			'continent' => 'EU',
+		),
+		'MH' => array(
+			'country' => 'Marshall Islands',
+			'continent' => 'OC',
+		),
+		'MQ' => array(
+			'country' => 'Martinique',
+			'continent' => 'NA',
+		),
+		'MR' => array(
+			'country' => 'Mauritania',
+			'continent' => 'AF',
+		),
+		'MU' => array(
+			'country' => 'Mauritius',
+			'continent' => 'AF',
+		),
+		'YT' => array(
+			'country' => 'Mayotte',
+			'continent' => 'AF',
+		),
+		'MX' => array(
+			'country' => 'Mexico',
+			'continent' => 'NA',
+		),
+		'FM' => array(
+			'country' => 'Micronesia',
+			'continent' => 'OC',
+		),
+		'MD' => array(
+			'country' => 'Moldova',
+			'continent' => 'EU',
+		),
+		'MC' => array(
+			'country' => 'Monaco',
+			'continent' => 'EU',
+		),
+		'MN' => array(
+			'country' => 'Mongolia',
+			'continent' => 'AS',
+		),
+		'ME' => array(
+			'country' => 'Montenegro',
+			'continent' => 'EU',
+		),
+		'MS' => array(
+			'country' => 'Montserrat',
+			'continent' => 'NA',
+		),
+		'MA' => array(
+			'country' => 'Morocco',
+			'continent' => 'AF',
+		),
+		'MZ' => array(
+			'country' => 'Mozambique',
+			'continent' => 'AF',
+		),
+		'MM' => array(
+			'country' => 'Myanmar',
+			'continent' => 'AS',
+		),
+		'NA' => array(
+			'country' => 'Namibia',
+			'continent' => 'AF',
+		),
+		'NR' => array(
+			'country' => 'Nauru',
+			'continent' => 'OC',
+		),
+		'NP' => array(
+			'country' => 'Nepal',
+			'continent' => 'AS',
+		),
+		'NL' => array(
+			'country' => 'Netherlands',
+			'continent' => 'EU',
+		),
+		'AN' => array(
+			'country' => 'Netherlands Antilles',
+			'continent' => 'NA',
+		),
+		'NC' => array(
+			'country' => 'New Caledonia',
+			'continent' => 'OC',
+		),
+		'NZ' => array(
+			'country' => 'New Zealand',
+			'continent' => 'OC',
+		),
+		'NI' => array(
+			'country' => 'Nicaragua',
+			'continent' => 'NA',
+		),
+		'NE' => array(
+			'country' => 'Niger',
+			'continent' => 'AF',
+		),
+		'NG' => array(
+			'country' => 'Nigeria',
+			'continent' => 'AF',
+		),
+		'NU' => array(
+			'country' => 'Niue',
+			'continent' => 'OC',
+		),
+		'NF' => array(
+			'country' => 'Norfolk Island',
+			'continent' => 'OC',
+		),
+		'MP' => array(
+			'country' => 'Northern Mariana Islands',
+			'continent' => 'OC',
+		),
+		'NO' => array(
+			'country' => 'Norway',
+			'continent' => 'EU',
+		),
+		'OM' => array(
+			'country' => 'Oman',
+			'continent' => 'AS',
+		),
+		'PK' => array(
+			'country' => 'Pakistan',
+			'continent' => 'AS',
+		),
+		'PW' => array(
+			'country' => 'Palau',
+			'continent' => 'OC',
+		),
+		'PS' => array(
+			'country' => 'Palestinia',
+			'continent' => 'AS',
+		),
+		'PA' => array(
+			'country' => 'Panama',
+			'continent' => 'NA',
+		),
+		'PG' => array(
+			'country' => 'Papua New Guinea',
+			'continent' => 'OC',
+		),
+		'PY' => array(
+			'country' => 'Paraguay',
+			'continent' => 'SA',
+		),
+		'PE' => array(
+			'country' => 'Peru',
+			'continent' => 'SA',
+		),
+		'PH' => array(
+			'country' => 'Philippines',
+			'continent' => 'AS',
+		),
+		'PN' => array(
+			'country' => 'Pitcairn',
+			'continent' => 'OC',
+		),
+		'PL' => array(
+			'country' => 'Poland',
+			'continent' => 'EU',
+		),
+		'PT' => array(
+			'country' => 'Portugal',
+			'continent' => 'EU',
+		),
+		'PR' => array(
+			'country' => 'Puerto Rico',
+			'continent' => 'NA',
+		),
+		'QA' => array(
+			'country' => 'Qatar',
+			'continent' => 'AS',
+		),
+		'RE' => array(
+			'country' => 'Reunion',
+			'continent' => 'AF',
+		),
+		'RO' => array(
+			'country' => 'Romania',
+			'continent' => 'EU',
+		),
+		'RU' => array(
+			'country' => 'Russian Federation',
+			'continent' => 'EU',
+		),
+		'RW' => array(
+			'country' => 'Rwanda',
+			'continent' => 'AF',
+		),
+		'SH' => array(
+			'country' => 'Saint Helena',
+			'continent' => 'AF',
+		),
+		'KN' => array(
+			'country' => 'Saint Kitts and Nevis',
+			'continent' => 'NA',
+		),
+		'LC' => array(
+			'country' => 'Saint Lucia',
+			'continent' => 'NA',
+		),
+		'PM' => array(
+			'country' => 'Saint Pierre and Miquelon',
+			'continent' => 'NA',
+		),
+		'VC' => array(
+			'country' => 'Saint Vincent and The Grenadines',
+			'continent' => 'NA',
+		),
+		'WS' => array(
+			'country' => 'Samoa',
+			'continent' => 'OC',
+		),
+		'SM' => array(
+			'country' => 'San Marino',
+			'continent' => 'EU',
+		),
+		'ST' => array(
+			'country' => 'Sao Tome and Principe',
+			'continent' => 'AF',
+		),
+		'SA' => array(
+			'country' => 'Saudi Arabia',
+			'continent' => 'AS',
+		),
+		'SN' => array(
+			'country' => 'Senegal',
+			'continent' => 'AF',
+		),
+		'RS' => array(
+			'country' => 'Serbia',
+			'continent' => 'EU',
+		),
+		'SC' => array(
+			'country' => 'Seychelles',
+			'continent' => 'AF',
+		),
+		'SL' => array(
+			'country' => 'Sierra Leone',
+			'continent' => 'AF',
+		),
+		'SG' => array(
+			'country' => 'Singapore',
+			'continent' => 'AS',
+		),
+		'SK' => array(
+			'country' => 'Slovakia',
+			'continent' => 'EU',
+		),
+		'SI' => array(
+			'country' => 'Slovenia',
+			'continent' => 'EU',
+		),
+		'SB' => array(
+			'country' => 'Solomon Islands',
+			'continent' => 'OC',
+		),
+		'SO' => array(
+			'country' => 'Somalia',
+			'continent' => 'AF',
+		),
+		'ZA' => array(
+			'country' => 'South Africa',
+			'continent' => 'AF',
+		),
+		'GS' => array(
+			'country' => 'South Georgia and The South Sandwich Islands',
+			'continent' => 'AN',
+		),
+		'ES' => array(
+			'country' => 'Spain',
+			'continent' => 'EU',
+		),
+		'LK' => array(
+			'country' => 'Sri Lanka',
+			'continent' => 'AS',
+		),
+		'SD' => array(
+			'country' => 'Sudan',
+			'continent' => 'AF',
+		),
+		'SR' => array(
+			'country' => 'Suriname',
+			'continent' => 'SA',
+		),
+		'SJ' => array(
+			'country' => 'Svalbard and Jan Mayen',
+			'continent' => 'EU',
+		),
+		'SZ' => array(
+			'country' => 'Swaziland',
+			'continent' => 'AF',
+		),
+		'SE' => array(
+			'country' => 'Sweden',
+			'continent' => 'EU',
+		),
+		'CH' => array(
+			'country' => 'Switzerland',
+			'continent' => 'EU',
+		),
+		'SY' => array(
+			'country' => 'Syrian Arab Republic',
+			'continent' => 'AS',
+		),
+		'TW' => array(
+			'country' => 'Taiwan, Province of China',
+			'continent' => 'AS',
+		),
+		'TJ' => array(
+			'country' => 'Tajikistan',
+			'continent' => 'AS',
+		),
+		'TZ' => array(
+			'country' => 'Tanzania, United Republic of',
+			'continent' => 'AF',
+		),
+		'TH' => array(
+			'country' => 'Thailand',
+			'continent' => 'AS',
+		),
+		'TL' => array(
+			'country' => 'Timor-leste',
+			'continent' => 'AS',
+		),
+		'TG' => array(
+			'country' => 'Togo',
+			'continent' => 'AF',
+		),
+		'TK' => array(
+			'country' => 'Tokelau',
+			'continent' => 'OC',
+		),
+		'TO' => array(
+			'country' => 'Tonga',
+			'continent' => 'OC',
+		),
+		'TT' => array(
+			'country' => 'Trinidad and Tobago',
+			'continent' => 'NA',
+		),
+		'TN' => array(
+			'country' => 'Tunisia',
+			'continent' => 'AF',
+		),
+		'TR' => array(
+			'country' => 'Turkey',
+			'continent' => 'AS',
+		),
+		'TM' => array(
+			'country' => 'Turkmenistan',
+			'continent' => 'AS',
+		),
+		'TC' => array(
+			'country' => 'Turks and Caicos Islands',
+			'continent' => 'NA',
+		),
+		'TV' => array(
+			'country' => 'Tuvalu',
+			'continent' => 'OC',
+		),
+		'UG' => array(
+			'country' => 'Uganda',
+			'continent' => 'AF',
+		),
+		'UA' => array(
+			'country' => 'Ukraine',
+			'continent' => 'EU',
+		),
+		'AE' => array(
+			'country' => 'United Arab Emirates',
+			'continent' => 'AS',
+		),
+		'GB' => array(
+			'country' => 'United Kingdom',
+			'continent' => 'EU',
+		),
+		'US' => array(
+			'country' => 'United States',
+			'continent' => 'NA',
+		),
+		'UM' => array(
+			'country' => 'United States Minor Outlying Islands',
+			'continent' => 'OC',
+		),
+		'UY' => array(
+			'country' => 'Uruguay',
+			'continent' => 'SA',
+		),
+		'UZ' => array(
+			'country' => 'Uzbekistan',
+			'continent' => 'AS',
+		),
+		'VU' => array(
+			'country' => 'Vanuatu',
+			'continent' => 'OC',
+		),
+		'VE' => array(
+			'country' => 'Venezuela',
+			'continent' => 'SA',
+		),
+		'VN' => array(
+			'country' => 'Viet Nam',
+			'continent' => 'AS',
+		),
+		'VG' => array(
+			'country' => 'Virgin Islands, British',
+			'continent' => 'NA',
+		),
+		'VI' => array(
+			'country' => 'Virgin Islands, U.S.',
+			'continent' => 'NA',
+		),
+		'WF' => array(
+			'country' => 'Wallis and Futuna',
+			'continent' => 'OC',
+		),
+		'EH' => array(
+			'country' => 'Western Sahara',
+			'continent' => 'AF',
+		),
+		'YE' => array(
+			'country' => 'Yemen',
+			'continent' => 'AS',
+		),
+		'ZM' => array(
+			'country' => 'Zambia',
+			'continent' => 'AF',
+		),
+		'ZW' => array(
+			'country' => 'Zimbabwe',
+			'continent' => 'AF',
+		),
 	);
 
 	return $countries;

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,0 +1,13 @@
+jQuery( document ).ready( function ( $ ) {
+
+    // When one of our notices are clicked, process it
+    $( '#wpbody' ).on( 'click', '.notice.wpengine-geoip', function () {
+        $.post( {
+            url: ajaxurl,
+            data: {
+                action: 'geoip_dismiss_notice',
+                key: $( this ).data( 'key' )
+            }
+        } );
+    } );
+} );

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,13 +1,24 @@
-jQuery( document ).ready( function ( $ ) {
+document.getElementById( 'wpbody' ).addEventListener( 'click', function ( event ) {
+    // If this wasn't a click on a notice-dismiss close button, then abort
+    if ( 'notice-dismiss' !== event.target.className ) {
+        return;
+    }
 
-    // When one of our notices are clicked, process it
-    $( '#wpbody' ).on( 'click', '.notice.wpengine-geoip', function () {
-        $.post( {
-            url: ajaxurl,
-            data: {
-                action: 'geoip_dismiss_notice',
-                key: $( this ).data( 'key' )
-            }
-        } );
-    } );
+    // This should be our parent div for the notice
+    var parent = event.path[ 1 ] || null;
+
+    // If the parent div doesn't have our wpengine-geoip class, then abort
+    if ( !parent || !parent.classList.includes( 'wpengine-geoip' ) ) {
+        return;
+    }
+
+    // Get our notice's key
+    var key = parent.attributes[ 'data-key' ].value || null;
+
+    // Send our POST request to admin-ajax
+    var http = new XMLHttpRequest();
+    var params = "action=geoip_dismiss_notice&key=" + key;
+    http.open( "POST", ajaxurl, true );
+    http.setRequestHeader( "Content-type", "application/x-www-form-urlencoded" );
+    http.send( params );
 } );

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wpengine, markkelnar, stevenkword, stephenlin, ryanshoover, taylor4484
 Tags: wpe, wpengine, geoip, localization, geolocation
 Requires at least: 3.0.1
-Tested up to: 4.5
+Tested up to: 4.8
 Stable tag: 1.2.1
 
 License: GPLv2 or later
@@ -100,14 +100,17 @@ Below are all the supported negative geography options, this allows to you HIDE 
 
 = Examples of the Content Shortcode =
 This will display “Content just for US visitors” strictly for visitors viewing from the United States.
+
 `[geoip-content country="US"] Content just for US visitors [/geoip-content]`
 
 
 This will display “Content just for everyone in Texas and California” strictly for visitors from Texas and California.
+
 `[geoip-content region="TX, CA."] Content just for everyone in Texas and California [/geoip-content]`
 
 
 You can mix and match geography and negative geography options to create verbose logic in a single shortcode:
+
 `[geoip-content country="US" not-city="Austin"]Content for US visitors but not for visitors in Austin[/geoip-content]`
 
 = Limitations =
@@ -148,6 +151,7 @@ The problem here is that Paris, Texas will be hidden. The solution? Just have tw
 **GOOD**
 
 `[geoip_content country="FR" not_city="Paris"]Fly to Paris for only $199![/geoip_content][geoip_content country="US"]Fly to Paris for only $199![/geoip_content]`
+
 == Adding an area into an omitted region ==
 
 You want to show an ad written in Spanish to all of South America except for Brazil. Brasilia, however, has enough Spanish speakers that you want to include Brasilia.
@@ -158,14 +162,16 @@ You want to show an ad written in Spanish to all of South America except for Bra
 
 **GOOD**
 
-`[geoip_content continent="SA" not_country="BR"]Venta de la Navidad en los adaptadores USB[/geoip_content]
-[geoip_content city="Brasilia"]Venta de la Navidad en los adaptadores USB[/geoip_content]`
+`[geoip_content continent="SA" not_country="BR"]Venta de la Navidad en los adaptadores USB[/geoip_content]`
+
+`[geoip_content city="Brasilia"]Venta de la Navidad en los adaptadores USB[/geoip_content]`
 
 == Calculate distance between points ==
 
 You have a utility function that will calculate the distance from your provided lat/lng coordinate to the visitor's location in either miles or kilometers. This can be useful for determining approximate distances, as results may be cached at the state or country level, depending on your configuration.
 
 Example use:
+
 `$latitude  = 30.268246;
 $longitude = -97.745992;
 $geo = WPEngine\GeoIp::instance();

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: wpengine, markkelnar, stevenkword, stephenlin, ryanshoover, taylor
 Tags: wpe, wpengine, geoip, localization, geolocation
 Requires at least: 3.0.1
 Tested up to: 4.5
-Stable tag: 1.2.0
+Stable tag: 1.2.1
 
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -127,17 +127,13 @@ You want to show an offer for free shipping to every state in the US *but* Alask
 
 **BAD**
 
-```
-[geoip_content country="US" not_state="AK, HI"]Lorem ipsum dolor sit amet[/geoip_content]
-```
+`[geoip_content country="US" not_state="AK, HI"]Lorem ipsum dolor sit amet[/geoip_content]`
 
 Instead, show it to all other 48 states
 
 **GOOD**
 
-```
-[geoip_content state="AL, AZ, AR, CA, CO, CT, DE, FL, GA, ID, IL, IN, IA, KS, KY, LA, ME, MD, MA, MI, MN, MS, MO, MT, NE, NV, NH, NJ, NM, NY, NC, ND, OH, OK, OR, PA, RI, SC, SD, TN, TX, UT, VT, VA, WA, WV, WI, WY"]Free shipping on all orders over $50![/geoip_content]
-```
+`[geoip_content state="AL, AZ, AR, CA, CO, CT, DE, FL, GA, ID, IL, IN, IA, KS, KY, LA, ME, MD, MA, MI, MN, MS, MO, MT, NE, NV, NH, NJ, NM, NY, NC, ND, OH, OK, OR, PA, RI, SC, SD, TN, TX, UT, VT, VA, WA, WV, WI, WY"]Free shipping on all orders over $50![/geoip_content]`
 
 == Duplicate location names ==
 
@@ -145,61 +141,55 @@ You want to show discount airfare on a flight to Paris, France. The content shou
 
 **BAD**
 
-```
-[geoip_content country="US, FR" not_city="Paris"]Fly to Paris for only $199![/geoip_content]
-```
+`[geoip_content country="US, FR" not_city="Paris"]Fly to Paris for only $199![/geoip_content]`
 
 The problem here is that Paris, Texas will be hidden. The solution? Just have two geoip_content shortcodes.
 
 **GOOD**
 
-```
-[geoip_content country="FR" not_city="Paris"]Fly to Paris for only $199![/geoip_content][geoip_content country="US"]Fly to Paris for only $199![/geoip_content]
-```
+`[geoip_content country="FR" not_city="Paris"]Fly to Paris for only $199![/geoip_content][geoip_content country="US"]Fly to Paris for only $199![/geoip_content]`
 == Adding an area into an omitted region ==
 
 You want to show an ad written in Spanish to all of South America except for Brazil. Brasilia, however, has enough Spanish speakers that you want to include Brasilia.
 
 **BAD**
 
-```
-[geoip_content continent="SA" not_country="BR" city="Brasilia"]Lorem ipsum dolor sit amet[/geoip_content]
-```
+`[geoip_content continent="SA" not_country="BR" city="Brasilia"]Lorem ipsum dolor sit amet[/geoip_content]`
 
 **GOOD**
 
-```
-[geoip_content continent="SA" not_country="BR"]Venta de la Navidad en los adaptadores USB[/geoip_content]
-[geoip_content city="Brasilia"]Venta de la Navidad en los adaptadores USB[/geoip_content]
-```
+`[geoip_content continent="SA" not_country="BR"]Venta de la Navidad en los adaptadores USB[/geoip_content]
+[geoip_content city="Brasilia"]Venta de la Navidad en los adaptadores USB[/geoip_content]`
 
 == Calculate distance between points ==
 
 You have a utility function that will calculate the distance from your provided lat/lng coordinate to the visitor's location in either miles or kilometers. This can be useful for determining approximate distances, as results may be cached at the state or country level, depending on your configuration.
 
 Example use:
-```
-$latitude  = 30.268246;
+`$latitude  = 30.268246;
 $longitude = -97.745992;
 $geo = WPEngine\GeoIp::instance();
 if ( false !== $geo->distance_to( $latitude, $longitude ) ) {
 	$miles_to_wp_engine = $geo->distance_to( $latitude, $longitude );
-}
-```
+}`
 
 == Testing Parameters ==
 You can use the following URL parameters to test how your localized content will appear to visitors from various geographic locations. You can add any of the parameters below to any URL of a page using the GeoIP shortcodes or API calls:
 
 Spoof visitor from the state of Texas:
+
 `yourdomain.com/?geoip&region=TX`
 
 Spoof visitor from the United States:
+
 `yourdomain.com/?geoip&country=US`
 
 Spoof visitor from Austin, Texas
+
 `yourdomain.com/?geoip&city=Austin`
 
 Spoof visitor from the U.S. zip code 78701:
+
 `yourdomain.com/?geoip&zip=78701`
 
 
@@ -235,6 +225,10 @@ Please contact the WP Engine [Support Team](https://my.wpengine.com/support#gene
 2. An example post using GeoIP shortcodes
 
 == Changelog ==
+
+= 1.2.1 =
+- When you dismiss the notice on development websites, it stays dismissed. Like it should.
+- The readme's code blocks actually have code in them now. Because what's the sense of a code block without code in it?
 
 = 1.2.0 =
 - Adds a utility function for calculating distances

--- a/wpengine-geoip.php
+++ b/wpengine-geoip.php
@@ -205,7 +205,7 @@ class GeoIp {
 	 * We want people to be able to test the plugin, so we'll include some url parameters that will spoof a location
 	 *
 	 * @since 1.1.0
-	 * @param  array $geos Array of values for the user's location
+	 * @param  array $geos Array of values for the user's location.
 	 * @return array       Modified version of the GeoIP location array based on url parameters
 	 */
 	public function get_test_parameters( $geos ) {
@@ -513,7 +513,8 @@ class GeoIp {
 			// WordPress doesn't like a dash in shortcode parameter labels.
 			// Just in case, check to see if the value has "not-" in it.
 			if ( ! $negate ) {
-				$inline_negate = $negate = preg_match( '/not?\-([^=]+)\=\"?([^"]+)\"?/', $value, $matches );
+				$negate = preg_match( '/not?\-([^=]+)\=\"?([^"]+)\"?/', $value, $matches );
+				$inline_negate = $negate;
 			}
 
 			// Label after the negation match.
@@ -677,7 +678,7 @@ class GeoIp {
 	 * As a favor to users, let's match some common synonyms
 	 *
 	 * @since 1.1.0
-	 * @param  string $label The address label that needs a synonym
+	 * @param  string $label The address label that needs a synonym.
 	 * @return string label
 	 */
 	private function match_label_synonyms( $label ) {

--- a/wpengine-geoip.php
+++ b/wpengine-geoip.php
@@ -1,16 +1,19 @@
 <?php
-/*
-Plugin Name: WP Engine GeoIP
-Version: 1.2.1
-Description: Create a personalized user experienced based on location.
-Author: WP Engine
-Author URI: http://wpengine.com
-Plugin URI: https://wordpress.org/plugins/wpengine-geoip/
-Text Domain: wpengine-geoip
-Domain Path: /languages
-*/
+/**
+ * Plugin Name: WP Engine GeoIP
+ * Version: 1.2.1
+ * Description: Create a personalized user experienced based on location.
+ * Author: WP Engine
+ * Author URI: http://wpengine.com
+ * Plugin URI: https://wordpress.org/plugins/wpengine-geoip/
+ * Text Domain: wpengine-geoip
+ * Domain Path: /languages
+ *
+ * @package wpengine-geoip
+ */
 
-/* Examples use of how to add geoip information to post content:
+/*
+Examples use of how to add geoip information to post content:
 
 function geoip_append_content( $content ) {
 	$geo = WPEngine\GeoIp::instance();
@@ -18,38 +21,70 @@ function geoip_append_content( $content ) {
 	return $content;
 }
 add_filter( 'the_content', 'geoip_append_content' );
-
 */
 
 namespace WPEngine;
 
-// Exit if this file is directly accessed
-if ( ! defined( 'ABSPATH' ) ) exit;
+// Exit if this file is directly accessed.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
+/**
+ * Base class for the GeoIP plugin
+ */
 class GeoIp {
 
-	// The single instance of this object.  No need to have more than one.
+	/**
+	 * The single instance of this object.  No need to have more than one.
+	 *
+	 * @var class
+	 */
 	private static $instance = null;
 
-	// The path to the plugin. Let's just make that function call once.
+	/**
+	 * The path to the plugin. Let's just make that function call once.
+	 *
+	 * @var string
+	 */
 	private $geoip_path;
 
-	// The geographical data loaded from the environment
+	/**
+	 * The geographical data loaded from the environment.
+	 *
+	 * @var array
+	 */
 	public $geos;
 
-	// A list of countries and their continents
+	/**
+	 * A list of countries and their continents.
+	 *
+	 * @var array
+	 */
 	public $countries;
 
-	// WP-Admin errors notices
+	/**
+	 * WP-Admin errors notices.
+	 *
+	 * @var array
+	 */
 	private $admin_notices;
 
-	// Text Domain
+	/**
+	 * Text Domain.
+	 *
+	 * @var string
+	 */
 	const TEXT_DOMAIN           = 'wpengine-geoip';
 
-	// Version Number
+	/**
+	 * Version Number.
+	 *
+	 * @var string
+	 */
 	const VERSION               = '1.2.1';
 
-	// Shortcodes
+	// Shortcodes.
 	const SHORTCODE_CONTINENT	= 'geoip-continent';
 	const SHORTCODE_COUNTRY     = 'geoip-country';
 	const SHORTCODE_REGION      = 'geoip-region';
@@ -67,18 +102,18 @@ class GeoIp {
 	 */
 	public static function init() {
 
-		// Initialize
+		// Initialize.
 		add_action( 'init', array( self::instance(), 'setup' ) );
 		add_action( 'init', array( self::instance(), 'action_init_register_shortcodes' ) );
 
-		// Enqueue our javascript
+		// Enqueue our javascript.
 		add_action( 'admin_enqueue_scripts', array( self::instance(), 'enqueue_admin_js' ) );
 
-		// Check for dependencies
-		add_action( 'admin_init', array( self::instance(), 'action_admin_init_check_plugin_dependencies' ), 9999 ); // check late
+		// Check for dependencies.
+		add_action( 'admin_init', array( self::instance(), 'action_admin_init_check_plugin_dependencies' ), 9999 ); // check late.
 		add_action( 'admin_notices', array( self::instance(), 'action_admin_notices' ) );
 
-		// Process AJAX requests
+		// Process AJAX requests.
 		add_action( 'wp_ajax_geoip_dismiss_notice', array( self::instance(), 'ajax_action_dismiss_notice' ) );
 	}
 
@@ -88,8 +123,11 @@ class GeoIp {
 	 * @since 0.1.0
 	 */
 	public static function instance() {
-		// create a new object if it doesn't exist.
-		is_null( self::$instance ) && self::$instance = new self;
+		// Create a new object if it doesn't exist.
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self;
+		}
+
 		return self::$instance;
 	}
 
@@ -102,7 +140,7 @@ class GeoIp {
 
 		$this->geoip_path = plugin_dir_path( __FILE__ );
 
-		// Get our array of countries and continents
+		// Get our array of countries and continents.
 		require_once( $this->geoip_path . '/inc/country-list.php' );
 
 		$this->countries = apply_filters( 'geoip_country_list', geoip_country_list() );
@@ -113,7 +151,7 @@ class GeoIp {
 
 		$this->geos = apply_filters( 'geoip_location_values', $this->geos );
 
-		// Prepopulate the admin notices array
+		// Prepopulate the admin notices array.
 		$this->admin_notices = array(
 			'info'    => array(),
 			'error'   => array(),
@@ -128,7 +166,12 @@ class GeoIp {
 	 * @since 1.2.1
 	 */
 	public function enqueue_admin_js() {
-		wp_enqueue_script( self::TEXT_DOMAIN . '-admin-js', plugins_url( 'js/admin.js', __FILE__ ), null, self::VERSION, true  );
+		// Only enqueue the JS if the notice will be showing.
+		if ( ! $this->helper_should_notice_show( 'dependency' ) ) {
+			return;
+		}
+
+		wp_enqueue_script( self::TEXT_DOMAIN . '-admin-js', plugins_url( 'js/admin.js', __FILE__ ), null, self::VERSION, true );
 	}
 
 	/**
@@ -162,21 +205,25 @@ class GeoIp {
 	 * We want people to be able to test the plugin, so we'll include some url parameters that will spoof a location
 	 *
 	 * @since 1.1.0
-	 * @return array modified version of the GeoIP location array based on url parameters
+	 * @param  array $geos Array of values for the user's location
+	 * @return array       Modified version of the GeoIP location array based on url parameters
 	 */
 	public function get_test_parameters( $geos ) {
 
 		$params = $_GET;
 
-		if( !isset( $params['geoip'] ) ) {
+		if ( ! isset( $params['geoip'] ) ) {
 			return $geos;
 		}
 
-		foreach( $params as $key => $value ) {
+		foreach ( $params as $key => $value ) {
+
+			$key = esc_attr( $key );
+			$value = esc_attr( $value );
 
 			$key = $this->match_label_synonyms( $key );
 
-			if( isset( $geos[ $key ] ) ) {
+			if ( isset( $geos[ $key ] ) ) {
 				$geos[ $key ] = $value;
 			}
 		}
@@ -188,17 +235,18 @@ class GeoIp {
 	 * Get Continent
 	 *
 	 * @since 1.1.0
-	 * @return string Two-letter continent code, e.g. EU for Europe
+	 * @param  string $country Two-letter country code.
+	 * @return string          Two-letter continent code, e.g. EU for Europe
 	 */
 	public function continent( $country = '' ) {
 
 		$continent = '';
 
-		if( empty( $country ) ) {
-			$country = $this->geos[ 'countrycode' ];
+		if ( empty( $country ) ) {
+			$country = $this->geos['countrycode'];
 		}
 
-		if( isset( $this->countries[ $country ] ) ) {
+		if ( isset( $this->countries[ $country ] ) ) {
 			$continent = $this->countries[ $country ]['continent'];
 		}
 
@@ -212,7 +260,7 @@ class GeoIp {
 	 * @return string Two-letter country code, e.g.) US for the United States of America
 	 */
 	public function country() {
-		return $this->geos[ 'countrycode' ];
+		return $this->geos['countrycode'];
 	}
 
 	/**
@@ -222,7 +270,7 @@ class GeoIp {
 	 * @return string Two-letter region code. e.g.) CA for California
 	 */
 	public function region() {
-		return $this->geos[ 'region' ];
+		return $this->geos['region'];
 	}
 
 	/**
@@ -232,7 +280,7 @@ class GeoIp {
 	 * @return mixed Description
 	 */
 	public function city() {
-		return $this->geos[ 'city' ];
+		return $this->geos['city'];
 	}
 
 	/**
@@ -242,7 +290,7 @@ class GeoIp {
 	 * @return mixed Description
 	 */
 	public function postal_code() {
-		return $this->geos[ 'postalcode' ];
+		return $this->geos['postalcode'];
 	}
 
 	/**
@@ -252,7 +300,7 @@ class GeoIp {
 	 * @return mixed Description
 	 */
 	public function latitude() {
-		return $this->geos[ 'latitude' ];
+		return $this->geos['latitude'];
 	}
 
 	/**
@@ -262,7 +310,7 @@ class GeoIp {
 	 * @return mixed Description
 	 */
 	public function longitude() {
-		return $this->geos[ 'longitude' ];
+		return $this->geos['longitude'];
 	}
 
 	/**
@@ -270,51 +318,50 @@ class GeoIp {
 	 *
 	 * @since  0.5.0
 	 * @uses add_shortcode()
-	 * @return null
 	 */
 	public function action_init_register_shortcodes() {
 
-		// Continent Shortcode
+		// Continent Shortcode.
 		if ( ! shortcode_exists( self::SHORTCODE_CONTINENT ) ) {
 			add_shortcode( self::SHORTCODE_CONTINENT, array( $this, 'do_shortcode_continent' ) );
 		}
 
-		// Country Shortcode
+		// Country Shortcode.
 		if ( ! shortcode_exists( self::SHORTCODE_COUNTRY ) ) {
 			add_shortcode( self::SHORTCODE_COUNTRY, array( $this, 'do_shortcode_country' ) );
 		}
 
-		// Region Shortcode
+		// Region Shortcode.
 		if ( ! shortcode_exists( self::SHORTCODE_REGION ) ) {
 			add_shortcode( self::SHORTCODE_REGION, array( $this, 'do_shortcode_region' ) );
 		}
 
-		// City Shortcode
+		// City Shortcode.
 		if ( ! shortcode_exists( self::SHORTCODE_CITY ) ) {
 			add_shortcode( self::SHORTCODE_CITY, array( $this, 'do_shortcode_city' ) );
 		}
 
-		// Postal Code Shortcode
+		// Postal Code Shortcode.
 		if ( ! shortcode_exists( self::SHORTCODE_POSTAL_CODE ) ) {
 			add_shortcode( self::SHORTCODE_POSTAL_CODE, array( $this, 'do_shortcode_postal_code' ) );
 		}
 
-		// Latitude Shortcode
+		// Latitude Shortcode.
 		if ( ! shortcode_exists( self::SHORTCODE_LATITUDE ) ) {
 			add_shortcode( self::SHORTCODE_LATITUDE, array( $this, 'do_shortcode_latitude' ) );
 		}
 
-		// Longitude Shortcode
+		// Longitude Shortcode.
 		if ( ! shortcode_exists( self::SHORTCODE_LONGITUDE ) ) {
 			add_shortcode( self::SHORTCODE_LONGITUDE, array( $this, 'do_shortcode_longitude' ) );
 		}
 
-		// Smart Location Shortcode
+		// Smart Location Shortcode.
 		if ( ! shortcode_exists( self::SHORTCODE_LOCATION ) ) {
 			add_shortcode( self::SHORTCODE_LOCATION, array( $this, 'do_shortcode_location' ) );
 		}
 
-		// Smart Location Shortcode
+		// Smart Location Shortcode.
 		if ( ! shortcode_exists( self::SHORTCODE_CONTENT ) ) {
 			add_shortcode( self::SHORTCODE_CONTENT, array( $this, 'do_shortcode_content' ) );
 		}
@@ -324,14 +371,15 @@ class GeoIp {
 	 * Output the current continent
 	 *
 	 * @since 1.1.0
+	 * @param  array $atts Shortcode attributes.
 	 * @return string Two-letter continent code
 	 */
 	function do_shortcode_continent( $atts ) {
 		$continent = '[' . self::SHORTCODE_CONTINENT . ']';
 
-		$country = $this->geos[ 'countrycode' ];
+		$country = $this->geos['countrycode'];
 
-		if( isset( $this->countries[ $country ] ) ) {
+		if ( isset( $this->countries[ $country ] ) ) {
 			$continent = $this->countries[ $country ]['continent'];
 		}
 		return $continent;
@@ -341,10 +389,11 @@ class GeoIp {
 	 * Output the current country
 	 *
 	 * @since  0.5.0
+	 * @param  array $atts Shortcode attributes.
 	 * @return string Two-letter country code
 	 */
 	function do_shortcode_country( $atts ) {
-		if( isset( $this->geos[ 'countrycode' ] ) ) {
+		if ( isset( $this->geos['countrycode'] ) ) {
 			return $this->country();
 		}
 		return '[' . self::SHORTCODE_COUNTRY . ']';
@@ -354,10 +403,11 @@ class GeoIp {
 	 * Output the current region
 	 *
 	 * @since  0.5.0
+	 * @param  array $atts Shortcode attributes.
 	 * @return string Two-letter region code
 	 */
 	function do_shortcode_region( $atts ) {
-		if( isset( $this->geos[ 'region' ] ) ) {
+		if ( isset( $this->geos['region'] ) ) {
 			return $this->region();
 		}
 		return '[' . self::SHORTCODE_REGION . ']';
@@ -367,10 +417,11 @@ class GeoIp {
 	 * Output the current city
 	 *
 	 * @since  0.5.0
+	 * @param  array $atts Shortcode attributes.
 	 * @return string City name
 	 */
 	function do_shortcode_city( $atts ) {
-		if( isset( $this->geos[ 'city' ] ) ) {
+		if ( isset( $this->geos['city'] ) ) {
 			return $this->city();
 		}
 		return '[' . self::SHORTCODE_CITY . ']';
@@ -380,10 +431,11 @@ class GeoIp {
 	 * Output the current postal code
 	 *
 	 * @since  0.6.0
+	 * @param  array $atts Shortcode attributes.
 	 * @return string postal code
 	 */
 	function do_shortcode_postal_code( $atts ) {
-		if( isset( $this->geos[ 'postalcode' ] ) ) {
+		if ( isset( $this->geos['postalcode'] ) ) {
 			return $this->postal_code();
 		}
 		return '[' . self::SHORTCODE_POSTAL_CODE . ']';
@@ -393,10 +445,11 @@ class GeoIp {
 	 * Output the current latitude
 	 *
 	 * @since  0.6.0
+	 * @param  array $atts Shortcode attributes.
 	 * @return string latitude
 	 */
 	function do_shortcode_latitude( $atts ) {
-		if( isset( $this->geos[ 'latitude' ] ) ) {
+		if ( isset( $this->geos['latitude'] ) ) {
 			return $this->latitude();
 		}
 		return '[' . self::SHORTCODE_LATITUDE . ']';
@@ -406,10 +459,11 @@ class GeoIp {
 	 * Output the current longitude
 	 *
 	 * @since  0.6.0
+	 * @param  array $atts Shortcode attributes.
 	 * @return string longitude
 	 */
 	function do_shortcode_longitude( $atts ) {
-		if( isset( $this->geos[ 'longitude' ] ) ) {
+		if ( isset( $this->geos['longitude'] ) ) {
 			return $this->longitude();
 		}
 		return '[' . self::SHORTCODE_LONGITUDE . ']';
@@ -419,15 +473,16 @@ class GeoIp {
 	 * Output the current human readable location, in a smart way.
 	 *
 	 * @since  0.5.0
+	 * @param  array $atts Shortcode attributes.
 	 * @return string $html
 	 */
 	function do_shortcode_location( $atts ) {
 
 		$city = $this->city();
-		if( isset( $city ) && ! empty( $city ) ) {
+		if ( isset( $city ) && ! empty( $city ) ) {
 			return trim( $this->city() . ', ' . $this->region() . ' ' . $this->country() );
 		}
-		//Fallback
+		// Fallback.
 		return trim( $this->region() . ' ' . $this->country() );
 	}
 
@@ -435,6 +490,8 @@ class GeoIp {
 	 * Output the content filtered by region
 	 *
 	 * @since 1.1.0
+	 * @param  array  $atts Shortcode attributes.
+	 * @param  string $content HTML content that comes between the shortcode tags.
 	 * @return string HTML
 	 */
 	function do_shortcode_content( $atts, $content = null ) {
@@ -443,80 +500,80 @@ class GeoIp {
 
 		$test_parameters = array();
 
-		// Process and organzie the test parameters
-		foreach( $atts as $label => $value ) {
+		// Process and organzie the test parameters.
+		foreach ( $atts as $label => $value ) {
 
-			// Intialize our negation parameters
+			// Intialize our negation parameters.
 			$negate = 0;
 			$inline_negate = 0;
 
-			// Check to see if the attribute has "not" in it
+			// Check to see if the attribute has "not" in it.
 			$negate = preg_match( '/not?[-_]?(.*)/', $label, $matches );
 
-			// WordPress doesn't like a dash in shortcode parameter labels
-			// Just in case, check to see if the value has "not-" in it
-			if( ! $negate ) {
+			// WordPress doesn't like a dash in shortcode parameter labels.
+			// Just in case, check to see if the value has "not-" in it.
+			if ( ! $negate ) {
 				$inline_negate = $negate = preg_match( '/not?\-([^=]+)\=\"?([^"]+)\"?/', $value, $matches );
 			}
 
-			// Label after the negation match
+			// Label after the negation match.
 			$label = $negate ? $matches[1] : $label;
 
-			// Value after the negation match
+			// Value after the negation match.
 			$value = $inline_negate ? $matches[2] : $value;
 
-			// Replace common synonyms with our values
+			// Replace common synonyms with our values.
 			$label = $this->match_label_synonyms( $label );
 
-			// Abort if the label doesn't match
-			if( !isset( $this->geos[ $label ] ) ) {
+			// Abort if the label doesn't match.
+			if ( ! isset( $this->geos[ $label ] ) ) {
 				continue;
 			}
 
-			// Find out if the value is comma delimited
+			// Find out if the value is comma delimited.
 			$test_values = (array) explode( ',',  $value );
 
-			// Add the value to the test parameters
+			// Add the value to the test parameters.
 			$test_parameters[ $label ] = array(
 				'test_values' => $test_values,
 				'negate' => $negate,
 				);
-		}
+		}// End foreach().
 
-		// Sort the test parameters by region type – largest to smallest
+		// Sort the test parameters by region type – largest to smallest.
 		uksort( $test_parameters, array( $this, 'compare_location_type' ) );
 
 		$test_parameters = apply_filters( 'geoip_test_parameters', $test_parameters, $atts );
 
-		// Process through parameters, testing to see if we have a match
-		foreach( $test_parameters as $label => $parameter ) {
+		// Process through parameters, testing to see if we have a match.
+		foreach ( $test_parameters as $label => $parameter ) {
 
 			$test_values = $parameter['test_values'];
 
 			$negate = $parameter['negate'];
 
-			// Sanitize the match value
+			// Sanitize the match value.
 			$match_value = strtolower( $this->geos[ $label ] );
 
-			// Sanitize the test values
-			foreach( $test_values as &$test_value ) {
+			// Sanitize the test values.
+			foreach ( $test_values as &$test_value ) {
 				$test_value = strtolower( trim( $test_value, " \t\"." ) );
 			}
 
-			$is_match = in_array( $match_value, $test_values );
+			$is_match = in_array( $match_value, $test_values, true );
 
 			$is_match = ! $negate ? $is_match : ! $is_match;
 
-			if( ! $is_match ) {
+			if ( ! $is_match ) {
 				$keep = false;
 			}
 		}
 
-		if( ! $keep ) {
+		if ( ! $keep ) {
 			return '';
 		}
 
-		// Process any shortcodes in the content
+		// Process any shortcodes in the content.
 		$content = do_shortcode( $content );
 
 		return apply_filters( 'geoip_content', $content, $atts );
@@ -528,6 +585,9 @@ class GeoIp {
 	 * Used for sorting location types from largest area to smallest area
 	 *
 	 * @since 1.1.2
+	 * @param  string $a Type of location.
+	 * @param  string $b Type of location.
+	 * @return int       Whether $a is more important than b
 	 */
 	public function compare_location_type( $a, $b ) {
 		$location_types = array(
@@ -541,7 +601,7 @@ class GeoIp {
 			'postalcode'   => 6,
 			);
 
-		if( isset( $location_types[ $a ] ) && isset( $location_types[ $b ] ) ) {
+		if ( isset( $location_types[ $a ] ) && isset( $location_types[ $b ] ) ) {
 			return $location_types[ $a ] - $location_types[ $b ];
 		} else {
 			return 0;
@@ -555,9 +615,12 @@ class GeoIp {
 	 * @since  0.5.0
 	 */
 	public function action_admin_init_check_plugin_dependencies() {
-		if ( ! $this->geos['active'] && ! get_user_meta( get_current_user_id(), self::TEXT_DOMAIN . '-notice-dismissed-dependency', true ) ) {
-			$notice = __( 'WP Engine GeoIP requires a <a href="%s">WP Engine account</a> with GeoIP enabled for full functionality. Only testing queries will work on this site.', self::TEXT_DOMAIN );
-			$this->admin_notices['warning']['dependency'] = sprintf( $notice, 'http://wpengine.com/plans/?utm_source=' . self::TEXT_DOMAIN );
+		$notice_key = 'dependency';
+
+		if ( $this->helper_should_notice_show( $notice_key ) ) {
+			/* translators: Tells users that the plugin won't automatically work if they're not in the right setup */
+			$notice = __( 'WP Engine GeoIP requires a <a href="%s">WP Engine account</a> with GeoIP enabled for full functionality. Only testing queries will work on this site.', 'wpengine-geoip' );
+			$this->admin_notices['warning'][ $notice_key ] = sprintf( $notice, 'http://wpengine.com/plans/?utm_source=' . self::TEXT_DOMAIN );
 		}
 	}
 
@@ -569,7 +632,7 @@ class GeoIp {
 	public function action_admin_notices() {
 		foreach ( $this->admin_notices as $type => $notices ) {
 			foreach ( $notices as $key => $notice ) {
-				echo "<div class=\"notice notice-{$type} wpengine-geoip is-dismissible\" data-key=\"{$key}\"><p>$notice</p></div>";
+				echo wp_kses( "<div class=\"notice notice-{$type} wpengine-geoip is-dismissible\" data-key=\"{$key}\"><p>$notice</p></div>" );
 			}
 		}
 	}
@@ -578,7 +641,6 @@ class GeoIp {
 	 * Process an AJAX request to dismiss any notices
 	 * Adds a user meta field marking when the notice was dismissed
 	 *
-	 * @param $_POST Contains the key for the notice that we're dismissing
 	 * @since 1.2.1
 	 */
 	public function ajax_action_dismiss_notice() {
@@ -586,28 +648,49 @@ class GeoIp {
 			return;
 		}
 
-		$meta_key = self::TEXT_DOMAIN . '-notice-dismissed-' . $_POST['key'];
+		$meta_key = self::TEXT_DOMAIN . '-notice-dismissed-' . esc_attr( wp_unslash( $_POST['key'] ) );
 
 		add_user_meta( get_current_user_id(), $meta_key, time(), true );
+	}
+
+	/**
+	 * Helper: Should a notice show in the dashboard?
+	 *
+	 * @since 1.2.1
+	 * @param  string $notice Key of the notice we're testing for.
+	 * @return bool           Should we show the notice or not.
+	 */
+	protected function helper_should_notice_show( $notice ) {
+		if ( ! $notice ) {
+			return false;
+		}
+
+		$is_active = $this->geos['active'];
+		$is_dismissed = get_user_meta( get_current_user_id(), self::TEXT_DOMAIN . '-notice-dismissed-' . $notice, true );
+
+		// false = GeoIP is active, or if we've dismissed the notice before.
+		// true = GeoIP is not active and we haven't dismissed the notice before.
+		return ! ( $is_active || $is_dismissed );
 	}
 
 	/**
 	 * As a favor to users, let's match some common synonyms
 	 *
 	 * @since 1.1.0
+	 * @param  string $label The address label that needs a synonym
 	 * @return string label
 	 */
 	private function match_label_synonyms( $label ) {
 
-		if( 'country' == $label ) {
+		if ( 'country' === $label ) {
 			$label = 'countrycode';
 		}
 
-		if( 'state' == $label ) {
+		if ( 'state' === $label ) {
 			$label = 'region';
 		}
 
-		if( 'zipcode' == $label || 'zip' == $label ) {
+		if ( 'zipcode' === $label || 'zip' === $label ) {
 			$label = 'postalcode';
 		}
 
@@ -627,33 +710,33 @@ class GeoIp {
 	 * }
 	 *
 	 * @link http://andrew.hedges.name/experiments/haversine/
-	 * @param float Latitude of the destination in degrees
-	 * @param float Longitude of the destination in degrees
-	 * @param bool  Whether to calculate the distance in kilometers or miles
-	 * @return float distance in miles
 	 * @since 1.2
+	 * @param  float $lat     Latitude of the destination in degrees.
+	 * @param  float $lng     Longitude of the destination in degrees.
+	 * @param  bool  $metric  Whether to calculate the distance in kilometers or miles.
+	 * @return float          Distance in miles
 	 */
 	public function distance_to( $lat, $lng, $metric = false ) {
 		$start_lat = deg2rad( $this->latitude() );
 		$start_lng = deg2rad( $this->longitude() );
 
-		// Test for null values passed into the function or a 0,0 coordinate for the user
-		// If either exist, abort. (0,0 is the result when coordinates fail)
+		// Test for null values passed into the function or a 0,0 coordinate for the user.
+		// If either exist, abort. (0,0 is the result when coordinates fail).
 		if ( is_null( $lat ) || is_null( $lng ) || ( empty( $start_lat ) && empty( $start_lng ) ) ) {
 			return false;
 		}
 
-		// Choose the right radius for the results: radius of the Earth in kilometers and miles
+		// Choose the right radius for the results: radius of the Earth in kilometers and miles.
 		$radius = $metric ? 6373 : 3961;
 
-		// Sanitize the user submitted variables
+		// Sanitize the user submitted variables.
 		$lat = floatval( $lat );
 		$lng = floatval( $lng );
 
 		$dlng = $lng - $start_lng;
 		$dlat = $lat - $start_lat;
 
-		// Calculate the distance
+		// Calculate the distance.
 		$a = ( sin( $dlat / 2 ) * sin( $dlat / 2 ) ) + ( cos( $lat ) * cos( $start_lat ) * sin( $dlng / 2 ) * sin( $dlng / 2 ) );
 		$c = 2 * atan2( sqrt( $a ), sqrt( 1 - $a ) );
 		$d = $radius * $c;
@@ -662,5 +745,5 @@ class GeoIp {
 	}
 }
 
-// Register the GeoIP instance
+// Register the GeoIP instance.
 GeoIp::init();


### PR DESCRIPTION
Dismissed notices should now stay dismissed and not come back on the next page load. We now save a piece of user meta if the notice has been dismissed and check to make sure that meta doesn't exist before we show the notice.

The readme code blocks should render correctly in the new plugin repo markdown processor. The markdown processor doesn't support the ``` code block format (maybe it used to?). And it only adds the `<pre><code></code></pre>` wrapper if there's a blank line between the code and the line above it.