### PR TITLE
Fix admin notice

### DIFF
--- a/wpengine-geoip.php
+++ b/wpengine-geoip.php
@@ -633,7 +633,7 @@ class GeoIp {
 	public function action_admin_notices() {
 		foreach ( $this->admin_notices as $type => $notices ) {
 			foreach ( $notices as $key => $notice ) {
-				echo wp_kses( "<div class=\"notice notice-{$type} wpengine-geoip is-dismissible\" data-key=\"{$key}\"><p>$notice</p></div>" );
+				echo wp_kses_post( "<div class=\"notice notice-{$type} wpengine-geoip is-dismissible\" data-key=\"{$key}\"><p>$notice</p></div>" );
 			}
 		}
 	}


### PR DESCRIPTION
I'm using this plugin on a site at the moment, and it's throwing errors on my local copy because of a recent [commit](https://github.com/wpengine/geoip/commit/2355b0e752f49a7798c32cb9461eb9ac30771a6b#diff-bfc4e8681b28147983313723601adadbR635) that added a call to `wp_kses` with only one argument.