### PR TITLE
Better escaping to get rid of potential fatal error

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -8,7 +8,7 @@ document.getElementById( 'wpbody' ).addEventListener( 'click', function ( event 
     var parent = event.path[ 1 ] || null;
 
     // If the parent div doesn't have our wpengine-geoip class, then abort
-    if ( !parent || !parent.classList.includes( 'wpengine-geoip' ) ) {
+    if ( !parent || -1 === jQuery.inArray( 'wpengine-geoip', parent.classList ) ) {
         return;
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wpengine, markkelnar, stevenkword, stephenlin, ryanshoover, taylor4484
 Tags: wpe, wpengine, geoip, localization, geolocation
 Requires at least: 3.0.1
-Tested up to: 4.8.1
+Tested up to: 4.8
 Stable tag: 1.2.2
 
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: wpengine, markkelnar, stevenkword, stephenlin, ryanshoover, taylor4484
 Tags: wpe, wpengine, geoip, localization, geolocation
 Requires at least: 3.0.1
-Tested up to: 4.8
-Stable tag: 1.2.1
+Tested up to: 4.8.1
+Stable tag: 1.2.2
 
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -231,6 +231,10 @@ Please contact the WP Engine [Support Team](https://my.wpengine.com/support#gene
 2. An example post using GeoIP shortcodes
 
 == Changelog ==
+
+= 1.2.2 =
+- We're escaping our output. AND we're escaping our output in a way where the code will actually work!
+- We've also gotten rid of any bleeding-edge JavaScript. Sure, it's cool. But a plugin that works for everybody is even cooler.
 
 = 1.2.1 =
 - When you dismiss the notice on development websites, it stays dismissed. Like it should.

--- a/wpengine-geoip.php
+++ b/wpengine-geoip.php
@@ -633,7 +633,13 @@ class GeoIp {
 	public function action_admin_notices() {
 		foreach ( $this->admin_notices as $type => $notices ) {
 			foreach ( $notices as $key => $notice ) {
-				echo wp_kses( "<div class=\"notice notice-{$type} wpengine-geoip is-dismissible\" data-key=\"{$key}\"><p>$notice</p></div>" );
+				?>
+				<div class="notice notice-<?php echo sanitize_text_field( $type ); ?> wpengine-geoip is-dismissible" data-key="<?php echo sanitize_text_field( $key ); ?>">
+					<p>
+						<?php echo sanitize_text_field( $notice ); ?>
+					</p>
+				</div>
+				<?php
 			}
 		}
 	}

--- a/wpengine-geoip.php
+++ b/wpengine-geoip.php
@@ -634,9 +634,9 @@ class GeoIp {
 		foreach ( $this->admin_notices as $type => $notices ) {
 			foreach ( $notices as $key => $notice ) {
 				?>
-				<div class="notice notice-<?php echo sanitize_text_field( $type ); ?> wpengine-geoip is-dismissible" data-key="<?php echo sanitize_text_field( $key ); ?>">
+				<div class="notice notice-<?php echo esc_attr( $type ); ?> wpengine-geoip is-dismissible" data-key="<?php echo esc_attr( $key ); ?>">
 					<p>
-						<?php echo sanitize_text_field( $notice ); ?>
+						<?php echo esc_html( $notice ); ?>
 					</p>
 				</div>
 				<?php

--- a/wpengine-geoip.php
+++ b/wpengine-geoip.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP Engine GeoIP
- * Version: 1.2.1
+ * Version: 1.2.2
  * Description: Create a personalized user experienced based on location.
  * Author: WP Engine
  * Author URI: http://wpengine.com


### PR DESCRIPTION
`wp_kses` is called incorrectly. The missing 2nd parameter can cause a fatal error on PHP7.

The `admin.js` file was using an (ECMA16 array function)[https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes] (`Array.prototype.includes()`). It now uses the jQuery equivalent (`$.inArray()`) for better browser compatibility. 