### PR TITLE
MAR-6159: Fix for location with apostrophe

### DIFF
--- a/wpengine-geoip.php
+++ b/wpengine-geoip.php
@@ -149,6 +149,8 @@ class GeoIp {
 
 		$this->geos = $this->get_test_parameters( $this->geos );
 
+		$this->geos = wp_unslash( $this->geos );
+
 		$this->geos = apply_filters( 'geoip_location_values', $this->geos );
 
 		// Prepopulate the admin notices array.


### PR DESCRIPTION
Added `wp_unslash` method before filter. Tested on personal install.

https://wordpress.org/support/topic/location-name-has-apostrophe/

@stevenkword @ryanshoover 