### PR TITLE
GeoIP to GeoTarget

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: wpengine, markkelnar, stevenkword, stephenlin, ryanshoover, taylor
 Tags: wpe, wpengine, geoip, localization, geolocation
 Requires at least: 3.0.1
 Tested up to: 4.9
-Stable tag: 1.2.3
+Stable tag: 1.2.4
 
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -231,6 +231,10 @@ Please contact the WP Engine [Support Team](https://my.wpengine.com/support).
 2. An example post using GeoTarget shortcodes
 
 == Changelog ==
+
+= 1.2.4 =
+- Updating branding to GeoTarget
+- Readme update
 
 = 1.2.3 =
 - Bumps version number for WP 4.9 compatibility

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== WP Engine GeoIP ===
+=== WP Engine GeoTarget ===
 Contributors: wpengine, markkelnar, stevenkword, stephenlin, ryanshoover, taylor4484
 Tags: wpe, wpengine, geoip, localization, geolocation
 Requires at least: 3.0.1
@@ -12,7 +12,7 @@ Create a personalized user experienced based on location.
 
 == Description ==
 
-WP Engine GeoIP integrates with the variables on your WP Engine site to display content catered to the visitor’s location. With the ability to access variables from as broad as country to as specific as latitude and longitude, your website can now display geographically relevant content.
+WP Engine GeoTarget integrates with the variables on your WP Engine site to display content catered to the visitor’s location. With the ability to access variables from as broad as country to as specific as latitude and longitude, your website can now display geographically relevant content.
 
 
 = Geo-Marketing =
@@ -42,7 +42,7 @@ This plugin will only function on your [WP Engine](http://wpengine.com/plans/?ut
 1. Upload `wpengine-geoip` to the `/wp-content/plugins/` directory
 2. Activate the plugin through the 'Plugins' menu in WordPress
 
-Please view the 'Other Notes' tab to see all of the available GeoIP shortcodes
+Please view the 'Other Notes' tab to see all of the available GeoTarget shortcodes
 
 
 == Location Variable Shortcodes ==
@@ -62,7 +62,7 @@ You can use any of the following location variable shortcodes to return the vari
 
 5) Postal Code: `[geoip-postalcode]`
 
-* This variable is only available in the US due to limitations with the location data GeoIP uses
+* This variable is only available in the US due to limitations with the location data GeoTarget uses
 
 6) Latitude: `[geoip-latitude]`
 
@@ -180,7 +180,7 @@ if ( false !== $geo->distance_to( $latitude, $longitude ) ) {
 }`
 
 == Testing Parameters ==
-You can use the following URL parameters to test how your localized content will appear to visitors from various geographic locations. You can add any of the parameters below to any URL of a page using the GeoIP shortcodes or API calls:
+You can use the following URL parameters to test how your localized content will appear to visitors from various geographic locations. You can add any of the parameters below to any URL of a page using the GeoTarget shortcodes or API calls:
 
 Spoof visitor from the state of Texas:
 
@@ -209,9 +209,9 @@ No, this will only work within the WP Engine environment. This will not work for
 
 2) Are there any other restrictions to using this plugin?
 
-Yes. Even though the GeoIP variables on the server are available to Business, Premium and Enterprise customers, you will still need to reach out to the [Support Team](https://my.wpengine.com/support#general-issue) to fully enable GeoIP for your site.
+Yes. On Startup, Growth, and Scale plans the GeoTarget feature is available as an add-on. For Business and Premium plans or once you have added the GeoTarget add-on you will need to reach out to the [Support Team](https://my.wpengine.com/support) to fully enable GeoTarget for your site.
 
-For Personal and Professional customers who are interested in GeoIP, please contact the [Support Team](https://my.wpengine.com/support#general-issue) as well.
+You can read our full GeoTarget activation guide [here](https://wpengine.com/support/geoip-personalizing-content-based-geography/).
 
 3) What variables do I have access to?
 
@@ -223,12 +223,12 @@ That’s easy! [Signup here](http://wpengine.com/plans/?utm_source=wpengine-geoi
 
 5) I installed the plugin and used a shortcode or API call and it isn’t working.
 
-Please contact the WP Engine [Support Team](https://my.wpengine.com/support#general-issue).
+Please contact the WP Engine [Support Team](https://my.wpengine.com/support).
 
 == Screenshots ==
 
-1. Authoring a new post with GeoIP shortcodes
-2. An example post using GeoIP shortcodes
+1. Authoring a new post with GeoTarget shortcodes
+2. An example post using GeoTarget shortcodes
 
 == Changelog ==
 

--- a/wpengine-geoip.php
+++ b/wpengine-geoip.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: WP Engine GeoIP
+ * Plugin Name: WP Engine GeoTarget
  * Version: 1.2.3
  * Description: Create a personalized user experienced based on location.
  * Author: WP Engine
@@ -31,7 +31,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Base class for the GeoIP plugin
+ * Base class for the GeoTarget plugin, GeoTarget was formerly called GeoIP
  */
 class GeoIp {
 
@@ -178,7 +178,7 @@ class GeoIp {
 	 * Here we extract the data from headers set by nginx -- lets only send them if they are part of the cache key
 	 *
 	 * @since 0.1.0
-	 * @return array All of the GeoIP related environment variables available on the current server instance
+	 * @return array All of the GeoTarget related environment variables available on the current server instance
 	 */
 	public function get_actuals() {
 
@@ -206,7 +206,7 @@ class GeoIp {
 	 *
 	 * @since 1.1.0
 	 * @param  array $geos Array of values for the user's location.
-	 * @return array       Modified version of the GeoIP location array based on url parameters
+	 * @return array       Modified version of the GeoTarget location array based on url parameters
 	 */
 	public function get_test_parameters( $geos ) {
 
@@ -620,7 +620,7 @@ class GeoIp {
 
 		if ( $this->helper_should_notice_show( $notice_key ) ) {
 			/* translators: Tells users that the plugin won't automatically work if they're not in the right setup */
-			$notice = __( 'WP Engine GeoIP requires a <a href="%s">WP Engine account</a> with GeoIP enabled for full functionality. Only testing queries will work on this site.', 'wpengine-geoip' );
+			$notice = __( 'WP Engine GeoTarget requires a <a href="%s">WP Engine account</a> with GeoTarget enabled for full functionality. Only testing queries will work on this site.', 'wpengine-geoip' );
 			$this->admin_notices['warning'][ $notice_key ] = sprintf( $notice, 'http://wpengine.com/plans/?utm_source=' . self::TEXT_DOMAIN );
 		}
 	}
@@ -675,8 +675,8 @@ class GeoIp {
 		$is_active = $this->geos['active'];
 		$is_dismissed = get_user_meta( get_current_user_id(), self::TEXT_DOMAIN . '-notice-dismissed-' . $notice, true );
 
-		// false = GeoIP is active, or if we've dismissed the notice before.
-		// true = GeoIP is not active and we haven't dismissed the notice before.
+		// false = GeoTarget is active, or if we've dismissed the notice before.
+		// true = GeoTarget is not active and we haven't dismissed the notice before.
 		return ! ( $is_active || $is_dismissed );
 	}
 
@@ -752,5 +752,5 @@ class GeoIp {
 	}
 }
 
-// Register the GeoIP instance.
+// Register the GeoTarget plugin instance.
 GeoIp::init();


### PR DESCRIPTION
Rebranding GeoIP to GeoTarget, updating readme to reflect GeoTarget add-on available for any account type.

No code changes, only comments and readme. Initial comment clarifies that GeoTarget was formerly called GeoIP in an attempt to clear up any confusion around the class name.

@ryanshoover @stevenkword 