### PR TITLE
CP-806 PHP 7.2 for GeoIP

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-# Holding at php 7.0 because WP test suite is incompatible with 7.2.
+# Tests pass with 7.2.
 FROM wordpress:php7.2
 
 # Install server dependencies.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Holding at php 7.0 because WP test suite is incompatible with 7.2.
-FROM wordpress:php7.0
+FROM wordpress:php7.2
 
 # Install server dependencies.
 RUN apt-get update && apt-get install -qq -y --fix-missing --no-install-recommends \


### PR DESCRIPTION
Update's PHP version o the WordPress docker image to 7.2. All tests pass except for 3 errors in `wpengine-geoip/js/admin.js` which should be easy to fix with PHPCBF if we want to build that into the Dockerfile in the future. 

```
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 3 ERRORS AFFECTING 2 LINES
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  7 | ERROR | [x] Opening parenthesis of a multi-line function call must be the last content on the line
    |       |     (PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket)
  7 | ERROR | [x] Only one argument is allowed per line in a multi-line function call (PEAR.Functions.FunctionCallSignature.MultipleArguments)
 30 | ERROR | [x] Closing parenthesis of a multi-line function call must be on a line by itself (PEAR.Functions.FunctionCallSignature.CloseBracketLine)
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 3 MARKED SNIFF VIOLATIONS AUTOMATICALLY
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

I also confirmed that the plugin functions on a WP Engine PHP 7.2 production environment. 