### PR TITLE
Update example usage of not_city

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ This will display “Content just for everyone in Texas and California” strict
 
 You can mix and match geography and negative geography options to create verbose logic in a single shortcode:
 
-> [geoip-content country="US" not-city="Austin"]Content for US visitors but not for visitors in Austin[/geoip-content]
+> [geoip-content country="US" not_city="Austin"]Content for US visitors but not for visitors in Austin[/geoip-content]
 
 #### Limitation
 

--- a/src/class-geoip.php
+++ b/src/class-geoip.php
@@ -510,7 +510,7 @@ class GeoIp {
 			$negate        = 0;
 			$inline_negate = 0;
 
-			// Check to see if the attribute has "not" in it.
+			// Check to see if the attribute has "not-" or "not_" in it.
 			$negate = preg_match( '/not?[-_]?(.*)/', $label, $matches );
 
 			// WordPress doesn't like a dash in shortcode parameter labels.

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -117,7 +117,7 @@ This will display “Content just for everyone in Texas and California” strict
 You can mix and match geography and negative geography options to create verbose logic in a single shortcode:
 
 `
-[geoip-content country="US" not-city="Austin"]Content for US visitors but not for visitors in Austin[/geoip-content]
+[geoip-content country="US" not_city="Austin"]Content for US visitors but not for visitors in Austin[/geoip-content]
 `
 
 = Limitations =


### PR DESCRIPTION
Saw example usage with '-' instead of '_' showing negation.  Code supports both, but documentation was confusing/inconsistent.  

Not functional changes here.