### PR TITLE
Check for existing countrycode before assigning it

### DIFF
--- a/src/class-geoip.php
+++ b/src/class-geoip.php
@@ -245,7 +245,7 @@ class GeoIp {
 
 		$continent = '';
 
-		if ( empty( $country ) ) {
+		if ( empty( $country ) && ! empty( $this->geos['countrycode'] ) ) {
 			$country = $this->geos['countrycode'];
 		}
 


### PR DESCRIPTION
On a development site with no geos set, if I call `WPEngine\GeoIp::instance()->continent()`, I'll get a notice thrown about a non-existent array value.

This PR checks that the array value isn't empty before trying to assign it.