### PR TITLE
Update class-geoip.php

### DIFF
--- a/src/class-geoip.php
+++ b/src/class-geoip.php
@@ -174,7 +174,7 @@ class GeoIp {
 		}
 
 		wp_enqueue_script( self::TEXT_DOMAIN . '-admin-js', plugins_url( 'js/admin.js', __FILE__ ), null, self::VERSION, true );
-		wp_localize_script( self::TEXT_DOMAIN . '-admin-js', 'nonce', wp_create_nonce( self::TEXT_DOMAIN ) );
+		wp_localize_script( self::TEXT_DOMAIN . '-admin-js', 'nonce', array( wp_create_nonce( self::TEXT_DOMAIN ) ) );
 	}
 
 	/**


### PR DESCRIPTION
wp_localize_script() which requires last parameter to be an array()